### PR TITLE
add auth  URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
-AUTH_SECRET="abcdefghijklmnopqrstuvwxyz012345" 
+AUTH_SECRET="abcdefghijklmnopqrstuvwxyz012345"
+AUTH_URL="http://localhost:3000"
 
 # Next Auth Discord Provider
 NEXT_PUBLIC_BASE_URL=http://localhost:3000

--- a/src/env.js
+++ b/src/env.js
@@ -11,6 +11,7 @@ export const env = createEnv({
       process.env.NODE_ENV === "production"
         ? z.string()
         : z.string().optional(),
+    AUTH_URL: z.string().url(),
     DATABASE_URL: z.string().url(),
 
     REDIS_HOST: z.string(),
@@ -43,6 +44,7 @@ export const env = createEnv({
    */
   runtimeEnv: {
     AUTH_SECRET: process.env.AUTH_SECRET,
+    AUTH_URL: process.env.AUTH_URL,
     DATABASE_URL: process.env.DATABASE_URL,
     NODE_ENV: process.env.NODE_ENV,
 

--- a/src/server/auth/config.ts
+++ b/src/server/auth/config.ts
@@ -6,8 +6,10 @@ import { db } from "@/server/db";
 import { accounts, users}  from "@/server/db/schema";
 import bcrypt from "bcryptjs";
 import type { JWT } from "next-auth/jwt";
+import { env } from "@/env";
 
 export const authConfig = {
+  trustHost: true, // Add this to trust the host
   providers: [
     CredentialsProvider({
       name: "Credentials",


### PR DESCRIPTION
## Summary by Sourcery

Add support for an AUTH_URL environment variable with URL validation and enable trustHost in the authentication config

Enhancements:
- Validate and expose AUTH_URL as a required environment variable
- Enable trustHost option in the NextAuth authentication configuration

Documentation:
- Include AUTH_URL in the .env.example file